### PR TITLE
Update libevhtp.rb formula to use sha256

### DIFF
--- a/Formula/libevhtp.rb
+++ b/Formula/libevhtp.rb
@@ -4,31 +4,31 @@ class Libevhtp < Formula
 
   url 'https://github.com/ellzey/libevhtp/archive/1.2.10.tar.gz'
   version '1.2.10'
-  sha1 'c481be3b26a4379e39d5952ff60a195f2c0e2176'
- 
+  sha256 '1cecc250a766cd6f5df35706181427cfcff62541a7a135a821eed9f61c9c8907'
+
   head 'https://github.com/ellzey/libevhtp.git'
- 
+
   depends_on 'cmake' => :build
   depends_on 'libevent'
-  
+
   depends_on 'openssl' => :recommended
   depends_on 'oniguruma' => :recommended
   depends_on 'jemalloc' => :optional
-  
+
   option "without-oniguruma", "Disable regex support"
   option "without-evthr", "Disable evthread support"
   option "with-shared", "Build shared library too"
- 
+
   def install
     args = ["."]
-    
+
     args << "-DEVHTP_DISABLE_SSL:STRING=ON" if build.without? "openssl"
     args << "-DEVHTP_DISABLE_REGEX:STRING=ON" if build.without? "oniguruma"
     args << "-DEVHTP_DISABLE_EVTHR:STRING=ON" if build.without? "evthr"
-    
+
     args << "-DEVHTP_BUILD_SHARED:STRING=ON" if build.with? "shared"
     args << "-DEVHTP_USE_JEMALLOC:STRING=ON" if build.with? "jemalloc"
-    
+
     system "cmake", *args, *std_cmake_args
     system "make install"
   end


### PR DESCRIPTION
This PR removes the following deprecation warnings for sha1 in homebrew, and removes excess whitespace in that `libevhtp.rb`.

```
Warning: Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Library/Taps/crossroadlabs/homebrew-tap/Formula/libevhtp.rb:7:in `<class:Libevhtp>'
Please report this to the crossroadlabs/tap tap!

Warning: Calling SoftwareSpec#sha1 is deprecated!
Use SoftwareSpec#sha256 instead.
/usr/local/Library/Taps/crossroadlabs/homebrew-tap/Formula/libevhtp.rb:7:in `<class:Libevhtp>'
Please report this to the crossroadlabs/tap tap!

Warning: Calling Resource#sha1 is deprecated!
Use Resource#sha256 instead.
/usr/local/Library/Taps/crossroadlabs/homebrew-tap/Formula/libevhtp.rb:7:in `<class:Libevhtp>'
Please report this to the crossroadlabs/tap tap!
```
